### PR TITLE
Add microsoft preview

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -162,6 +162,7 @@
         layer.open({
             type: 2,
             shade: 0.2,
+            area: ["800px", "500px"],
             shadeClose: true,
             title: lang.preview,
             skin: 'layer-preview-powerpoint',

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -156,5 +156,18 @@
 </div>
 
 <script init="{{ $selector }}" require="@select-table,@select2?lang={{ config('app.locale') === 'en' ? '' : str_replace('_', '-', config('app.locale')) }},@de-memory.dcat-media-selector">
-    new MediaSelector({!! $config !!}, '{{ $locale }}', {!! $lang !!}).init();
+    var lang = {!! $lang !!};
+    @if($useMicrosoftPreview)
+    MediaSelector.prototype.previewPowerpoint = function (url) {
+        layer.open({
+            type: 2,
+            shade: 0.2,
+            shadeClose: true,
+            title: lang.preview,
+            skin: 'layer-preview-powerpoint',
+            content: 'http://view.officeapps.live.com/op/view.aspx?src=' + url
+        });
+    }
+    @endif
+    new MediaSelector({!! $config !!}, '{{ $locale }}', lang).init();
 </script>

--- a/src/MediaSelector.php
+++ b/src/MediaSelector.php
@@ -13,6 +13,8 @@ class MediaSelector extends Field
 
     protected $selectList;
 
+    protected $useMicrosoftPreview = false;
+
     public function __construct($column, $arguments = [])
     {
         parent::__construct($column, $arguments);
@@ -64,6 +66,13 @@ class MediaSelector extends Field
     public function sortable(bool $sortable = true)
     {
         return $this->options(['sortable' => $sortable]);
+    }
+
+    public function useMicrosoftPreview(bool $useMicrosoftPreview = true)
+    {
+        $this->useMicrosoftPreview = $useMicrosoftPreview;
+
+        return $this;
     }
 
     public function render()
@@ -155,6 +164,7 @@ class MediaSelector extends Field
             'config' => $config,
             'locale' => $locale,
             'lang' => $lang,
+            'useMicrosoftPreview' => $this->useMicrosoftPreview,
         ]);
 
         return parent::render();


### PR DESCRIPTION
用法：

```
$form->mediaSelector('field')->useMicrosoftPreview();
```

### 局限性： 

- 文档的URL必须是可以外部直接访问的。
- 文档的预览依赖于Microsoft的文档预览，有泄密风险，需自行考量。